### PR TITLE
#16. 진단 요청 처리 개선 및 에러 UI 정리

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -3,6 +3,9 @@ document.addEventListener('alpine:init', () => {
         nickname: '',
         report: null,
         loading: false,
+        errorMessage: '',
+        activeRequestNickname: '',
+        requestController: null,
         viewMode: 'top5',
         showHelp: false,
         helpTab: 'guide',
@@ -23,22 +26,67 @@ document.addEventListener('alpine:init', () => {
         },
 
         reset() {
+            if (this.requestController) {
+                this.requestController.abort();
+                this.requestController = null;
+            }
             this.report = null;
             this.nickname = '';
+            this.errorMessage = '';
+            this.loading = false;
+            this.activeRequestNickname = '';
             this.viewMode = 'top5';
         },
 
         async fetchReport() {
-            if(!this.nickname) return;
-            this.loading = true;
-            this.viewMode = 'top5';
-            try {
-                const res = await fetch(`/check-items/${this.nickname}`);
-                this.report = await res.json();
-            } catch(e) {
-                alert('진단 실패: 서버 연결을 확인하세요.');
+            const trimmedNickname = this.nickname.trim();
+            if (!trimmedNickname) return;
+
+            if (this.loading && this.requestController && trimmedNickname === this.activeRequestNickname) {
+                return;
             }
-            this.loading = false;
+
+            if (this.requestController) {
+                this.requestController.abort();
+            }
+
+            const controller = new AbortController();
+            this.requestController = controller;
+            this.activeRequestNickname = trimmedNickname;
+            this.nickname = trimmedNickname;
+            this.loading = true;
+            this.errorMessage = '';
+            this.viewMode = 'top5';
+
+            try {
+                const res = await fetch(`/check-items/${encodeURIComponent(trimmedNickname)}`, {
+                    signal: controller.signal
+                });
+                const data = await res.json();
+
+                if (!res.ok) {
+                    throw new Error('서버 요청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+                }
+
+                if (data?.error) {
+                    throw new Error(data.error);
+                }
+
+                this.report = data;
+            } catch(e) {
+                if (e.name === 'AbortError') {
+                    return;
+                }
+
+                this.report = null;
+                this.errorMessage = e.message || '진단 실패: 서버 연결을 확인하세요.';
+            } finally {
+                if (this.requestController === controller) {
+                    this.requestController = null;
+                    this.loading = false;
+                    this.activeRequestNickname = '';
+                }
+            }
         },
 
         getFilteredItems() {

--- a/app/templates/components/_header.html
+++ b/app/templates/components/_header.html
@@ -9,11 +9,29 @@
         </button>
     </div>
 
-    <div class="bg-white p-3 rounded-2xl shadow-sm border border-slate-200 flex gap-2 transition-layout" :class="report ? 'w-full md:w-[36rem] shadow-none border-b-2 rounded-none bg-transparent border-slate-300' : 'w-full'">
-        <input x-model="nickname" @keyup.enter="fetchReport()" type="text" placeholder="캐릭터 닉네임 입력" class="flex-1 border-none bg-slate-100/50 rounded-xl px-4 py-2 outline-none transition-all font-medium" :class="report ? 'text-base bg-white' : 'text-lg'">
-        <button @click="fetchReport()" class="bg-blue-600 text-white px-6 py-2 rounded-xl font-bold hover:bg-blue-700 transition-all min-w-[100px]">
-            <span x-show="!loading" x-text="report ? '재검진' : '검진 시작'"></span>
-            <span x-show="loading" class="animate-spin inline-block">⏳</span>
-        </button>
+    <div class="w-full" :class="report ? 'md:w-[36rem]' : ''">
+        <div class="bg-white p-3 rounded-2xl shadow-sm border border-slate-200 flex gap-2 transition-layout" :class="report ? 'w-full shadow-none border-b-2 rounded-none bg-transparent border-slate-300' : 'w-full'">
+            <input x-model="nickname" @keyup.enter="fetchReport()" type="text" placeholder="캐릭터 닉네임 입력" class="flex-1 border-none bg-slate-100/50 rounded-xl px-4 py-2 outline-none transition-all font-medium" :class="report ? 'text-base bg-white' : 'text-lg'">
+            <button @click="fetchReport()" class="bg-blue-600 text-white px-6 py-2 rounded-xl font-bold hover:bg-blue-700 transition-all min-w-[100px]">
+                <span x-show="!loading" x-text="report ? '재검진' : '검진 시작'"></span>
+                <span x-show="loading" class="animate-spin inline-block">⏳</span>
+            </button>
+        </div>
+
+        <div x-cloak x-show="errorMessage" class="mt-4 relative overflow-hidden rounded-2xl border border-rose-200/80 bg-gradient-to-r from-rose-50 via-white to-orange-50 px-4 py-4 shadow-[0_10px_30px_rgba(244,63,94,0.08)]">
+            <div class="absolute inset-y-0 left-0 w-1.5 bg-gradient-to-b from-rose-400 to-orange-300"></div>
+            <div class="flex items-center gap-4 pl-2">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white text-rose-500 shadow-sm ring-1 ring-rose-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M10.29 3.86l-7.55 13.09A2 2 0 004.47 20h15.06a2 2 0 001.73-3.05L13.71 3.86a2 2 0 00-3.42 0z" />
+                    </svg>
+                </div>
+                <div class="min-w-0 flex-1">
+                    <p class="text-[11px] font-black uppercase tracking-[0.22em] text-rose-400">Lookup Error</p>
+                    <p class="mt-1 text-lg font-black tracking-tight text-slate-900">캐릭터 정보를 불러오지 못했습니다.</p>
+                    <p class="mt-1.5 text-sm leading-relaxed text-slate-600" x-text="'캐릭터 이름을 다시 확인한 뒤 재시도해주세요.'"></p>
+                </div>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## 작업 내용

진단 요청 흐름에서 발생할 수 있는 중복 요청과 에러 처리 방식을 개선했습니다.

주요 변경 사항:
- 동일 닉네임 조회 중 중복 요청이 발생하지 않도록 방지
- 새로운 조회가 시작되면 이전 요청을 `AbortController`로 취소하도록 처리
- `alert` 기반 에러 안내를 제거하고, 입력 영역 하단에 인라인 에러 UI로 표시
- 에러 안내 박스의 시각적 스타일을 정리해 기존 화면 톤과 자연스럽게 맞추도록 개선

## 변경 파일

- `app/static/js/app.js`
- `app/templates/components/_header.html`

## 상세 설명

### 1. 요청 처리 개선
`fetchReport()` 실행 시 현재 진행 중인 요청 상태를 확인하도록 변경했습니다.

- 같은 닉네임으로 연속 조회할 경우 추가 요청을 막음
- 다른 닉네임으로 다시 조회할 경우 이전 요청을 취소하고 최신 요청만 유지
- 진행 중 요청은 `reset()` 시에도 정리되도록 처리

### 2. 에러 처리 방식 개선
기존에는 조회 실패 시 `alert`로만 안내하고 있었으나, 이를 화면 내부 메시지로 변경했습니다.

- 브라우저 기본 팝업 제거
- 입력창 아래에 인라인 에러 메시지 노출
- 사용자 흐름을 끊지 않고 에러 원인을 자연스럽게 전달

### 3. 에러 UI 개선
에러 메시지 박스를 단순한 빨간 배경에서 카드형 경고 UI로 정리했습니다.

- 좌측 포인트 바 추가
- 경고 아이콘 강조
- 타이포 계층 정리
- 안내 문구 가독성 개선

## 테스트 방법

1. 로컬 서버 실행
   ```bash
   source .venv/bin/activate
   uvicorn app.main:app --reload
